### PR TITLE
Implement multi-template option

### DIFF
--- a/.github/workflows/tests/check_outputs.py
+++ b/.github/workflows/tests/check_outputs.py
@@ -7,6 +7,7 @@ output_dir = f"{home_dir}/work/gist-geckos/gist-geckos/NGC0000Example"
 with open(f"{output_dir}/LOGFILE") as f:
 	for line in f:
 		print(line)
+print('I got up to here!')
 #Check the output directory is created 
 assert os.path.isdir(output_dir), "Output dir not created"
 assert os.path.isdir(f"{output_dir}/maps"), "Maps dir not created"

--- a/.github/workflows/tests/check_outputs.py
+++ b/.github/workflows/tests/check_outputs.py
@@ -4,6 +4,9 @@ home_dir = os.path.expanduser('~')
 print(home_dir)
 output_dir = f"{home_dir}/work/gist-geckos/gist-geckos/NGC0000Example"
 
+with open(f"{output_dir}/LOGFILE") as f:
+	for line in f:
+		print(line)
 #Check the output directory is created 
 assert os.path.isdir(output_dir), "Output dir not created"
 assert os.path.isdir(f"{output_dir}/maps"), "Maps dir not created"

--- a/.github/workflows/tests/gistTutorial/configFiles/MasterConfig.yaml
+++ b/.github/workflows/tests/gistTutorial/configFiles/MasterConfig.yaml
@@ -7,7 +7,6 @@ GENERAL :
   PARALLEL: True # Use multiprocessing [True/False]
   NCPU : 4 # Number of cores to use for multiprocessing
   LSF_DATA : 'lsf_MUSE-WFM' # Path of the file specifying the line-spread-function of the observational data. The specified path is relative to the configDir path in defaultDir.
-  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
   OW_CONFIG : True #  Ignore configurations from previous runs which are saved in the CONFIG file in the output directory [True/False]
   OW_OUTPUT : True # Overwrite any output files already present in the current output directory [True/False]
 
@@ -39,12 +38,6 @@ PREPARE_SPECTRA :
   METHOD : 'default'
   VELSCALE : 70
 
-# Prepare templates module
-PREPARE_TEMPLATES :
-  METHOD : 'miles'
-  LIBRARY : 'MILES/'
-  NORM_TEMP : 'LIGHT'
-
 # Stellar kinematics module
 KIN :
   METHOD : 'ppxf'
@@ -57,7 +50,11 @@ KIN :
   MDEG : 0
   REDDENING : null # As opposed to None
   MC_PPXF : 0
-
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  TEMPLATE_SET : 'miles'
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
+  
 # Emission line fitting module
 GAS :
   METHOD : 'gandalf'
@@ -68,7 +65,11 @@ GAS :
   REDDENING : 0.1,0.1
   EBmV : null # As opposed to None
   EMI_FILE : 'emissionLines.config'
-
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  TEMPLATE_SET : 'miles'
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
+  
 # Star formation histories module
 SFH :
   METHOD : 'ppxf'
@@ -80,7 +81,11 @@ SFH :
   REGUL_ERR : 1.
   NOISE : 1.
   FIXED : True
-
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  TEMPLATE_SET : 'miles'
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
+  
 # Line strenghts module
 LS :
   METHOD : 'default'
@@ -91,3 +96,8 @@ LS :
   MC_LS : 30
   NWALKER : 10
   NCHAIN : 100
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  TEMPLATE_SET : 'miles'
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
+  

--- a/.github/workflows/tests/gistTutorial/configFiles/MasterConfig.yaml
+++ b/.github/workflows/tests/gistTutorial/configFiles/MasterConfig.yaml
@@ -1,4 +1,4 @@
-# This is a test config file
+# This is a test config file Updated 06/04/2023
 GENERAL :
   RUN_ID : 'NGC0000Example' # Name of the analysis run. A subdirectory of this name within the output directory will be created. This identifier further serves as a prefix to all output files.
   INPUT : 'NGC0000.fits' # Input file for this analysis run. The specified path is relative to the input path given in defaultDir.

--- a/gistPipeline/emissionLines/gandalf.py
+++ b/gistPipeline/emissionLines/gandalf.py
@@ -24,14 +24,14 @@ PURPOSE:
   interface between pipeline and the pyGandALF routine
   (ui.adsabs.harvard.edu/?#abs/2006MNRAS.366.1151S; ui.adsabs.harvard.edu/abs/2006MNRAS.369..529F;
   ui.adsabs.harvard.edu/abs/2019arXiv190604746B) by implementing the input/output as well as
-  preparation of data and eventually calling pyGandALF. 
+  preparation of data and eventually calling pyGandALF.
 """
 
 
 def workerGANDALF(inQueue, outQueue):
     """
     Defines the worker process of the parallelisation with multiprocessing.Queue
-    and multiprocessing.Process. 
+    and multiprocessing.Process.
     """
     for spectra, error, stellar_kin, templates, logLam_galaxy, logLam_template, emi_file, redshift, velscale, int_disp,\
         reddening, mdeg, for_errors, offset, velscale_ratio, i, nbins, npix, config, maskedSpaxel\
@@ -48,7 +48,7 @@ def run_gandalf(spectrum, error, stellar_kin, templates, logLam_galaxy, logLam_t
                 velscale, int_disp, reddening, mdeg, for_errors, offset, velscale_ratio, i, nbins, npix, config,\
                 maskedSpaxel):
     """
-    Calls the pyGandALF routine (ui.adsabs.harvard.edu/?#abs/2006MNRAS.366.1151S; 
+    Calls the pyGandALF routine (ui.adsabs.harvard.edu/?#abs/2006MNRAS.366.1151S;
     ui.adsabs.harvard.edu/abs/2006MNRAS.369..529F; ui.adsabs.harvard.edu/abs/2019arXiv190604746B)
     """
     printStatus.progressBar( i, nbins, barLength=50 )
@@ -57,27 +57,27 @@ def run_gandalf(spectrum, error, stellar_kin, templates, logLam_galaxy, logLam_t
     plot  = False;  degree = -1
     quiet = True ;  log10  = False
 
-    if maskedSpaxel == False: 
+    if maskedSpaxel == False:
         try:
             # Get goodpixels and emission_setup
             goodpixels, emission_setup = getGoodpixelsEmissionSetup\
                     (config, redshift, velscale, logLam_galaxy, logLam_template, npix)
-            
+
             # Initial guess on velocity: Use value relative to stellar kinematics
             for itm in np.arange(len(emission_setup)):
-                emission_setup[itm].v = emission_setup[itm].v + stellar_kin[0] 
-            
+                emission_setup[itm].v = emission_setup[itm].v + stellar_kin[0]
+
             # Run GANDALF
             weights, emission_templates, bestfit, sol, esol = gandalf.gandalf\
                     ( templates, spectrum, error, velscale, stellar_kin, emission_setup, logLam_galaxy[0], \
                       logLam_galaxy[1]-logLam_galaxy[0], goodpixels, degree, mdeg, int_disp, plot, quiet, log10, reddening,\
                       logLam_template[0], for_errors, velscale_ratio, offset)
-            
+
             return( [weights, emission_templates, bestfit, sol, esol] )
-        
+
         except:
             return( [-1, -1, -1, -1, -1] )
-    else: 
+    else:
         return( [np.nan, np.nan, np.nan, np.nan, np.nan] )
 
 
@@ -91,7 +91,7 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
     # SAVE RESULTS
     outfits = os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_gas_'+currentLevel+'.fits'
     printStatus.running("Writing: "+config['GENERAL']['RUN_ID']+'_gas_'+currentLevel+'.fits')
-    
+
     # Primary HDU
     priHDU = fits.PrimaryHDU()
 
@@ -104,28 +104,28 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 
     gandalfOutput = Table()
     gandalfErrorOutput = Table()
-    for i in range(len(idx_l)): 
+    for i in range(len(idx_l)):
         if np.any(sol_gas_AoN[:,i]) != 0.0:
             gandalfOutput[names[i]+'_'+lambdas[i]+'_F'] = sol[:,i*4+0]
             gandalfOutput[names[i]+'_'+lambdas[i]+'_A'] = sol[:,i*4+1]
             gandalfOutput[names[i]+'_'+lambdas[i]+'_V'] = sol[:,i*4+2]
             gandalfOutput[names[i]+'_'+lambdas[i]+'_S'] = sol[:,i*4+3]
             gandalfOutput[names[i]+'_'+lambdas[i]+'_AON'] = sol_gas_AoN[:,i]
-            if for_errors: 
+            if for_errors:
                 gandalfErrorOutput[names[i]+'_'+lambdas[i]+'_FERR'] = esol[:,i*4+0]
                 gandalfErrorOutput[names[i]+'_'+lambdas[i]+'_AERR'] = esol[:,i*4+1]
                 gandalfErrorOutput[names[i]+'_'+lambdas[i]+'_VERR'] = esol[:,i*4+2]
                 gandalfErrorOutput[names[i]+'_'+lambdas[i]+'_SERR'] = esol[:,i*4+3]
 
-    if reddening != None: 
+    if reddening != None:
         gandalfOutput['EBmV_0'] = sol[:,len(idx_l)*4]
         gandalfOutput['EBmV_1'] = sol[:,len(idx_l)*4+1]
-        if for_errors: 
+        if for_errors:
             gandalfErrorOutput['EBmVERR_0'] = esol[:,len(idx_l)*4]
             gandalfErrorOutput['EBmVERR_1'] = esol[:,len(idx_l)*4+1]
 
     dataHDU = fits.BinTableHDU(gandalfOutput)
-    if for_errors: 
+    if for_errors:
         errorHDU = fits.BinTableHDU(gandalfErrorOutput)
 
     # Create HDU list and write to file
@@ -139,7 +139,7 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
     else:
         HDUList = fits.HDUList([priHDU, dataHDU])
     HDUList.writeto(outfits, overwrite=True)
-     
+
     printStatus.updateDone("Writing: "+config['GENERAL']['RUN_ID']+'_gas_'+currentLevel+'.fits')
     logging.info("Wrote: "+outfits)
 
@@ -148,10 +148,10 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
     # SAVE BESTFIT
     outfits = os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_gas-bestfit_'+currentLevel+'.fits'
     printStatus.running("Writing: "+config['GENERAL']['RUN_ID']+'_gas-bestfit_'+currentLevel+'.fits')
-    
+
     # Primary HDU
     priHDU = fits.PrimaryHDU()
-    
+
     # Extension 1: Table HDU with optimal templates
     cols = []
     cols.append( fits.Column(name='BESTFIT', format=str(bestfit.shape[1])+'D', array=bestfit ) )
@@ -178,10 +178,10 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 
     HDUList = fits.HDUList([priHDU, dataHDU, logLamHDU, goodpixHDU])
     HDUList.writeto(outfits, overwrite=True)
-    
+
     printStatus.updateDone("Writing: "+config['GENERAL']['RUN_ID']+'_gas-bestfit_'+currentLevel+'.fits')
     logging.info("Wrote: "+outfits)
-   
+
 
     # ========================
     # SAVE EMISSION
@@ -206,16 +206,16 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 
     printStatus.updateDone("Writing: "+config['GENERAL']['RUN_ID']+'_gas-emission_'+currentLevel+'.fits')
     logging.info("Wrote: "+outfits)
-   
-   
+
+
     # ========================
     # SAVE CLEANED SPECTRA
     outfits = os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_gas-cleaned_'+currentLevel+'.fits'
     printStatus.running("Writing: "+config['GENERAL']['RUN_ID']+'_gas-cleaned_'+currentLevel+'.fits')
-    
+
     # Primary HDU
     priHDU = fits.PrimaryHDU()
-    
+
     # Extension 1: Table HDU with optimal templates
     cols = []
     cols.append( fits.Column(name='SPEC', format=str(npix)+'D', array=cleaned_spectrum ) )
@@ -227,7 +227,7 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
     cols.append( fits.Column(name='LOGLAM', format='D', array=logLam_galaxy) )
     logLamHDU = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
     logLamHDU.name = 'LOGLAM'
-     
+
     # Create HDU list and write to file
     priHDU    = _auxiliary.saveConfigToHeader(priHDU, config['GAS'])
     dataHDU   = _auxiliary.saveConfigToHeader(dataHDU, config['GAS'])
@@ -235,34 +235,34 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 
     HDUList = fits.HDUList([priHDU, dataHDU, logLamHDU])
     HDUList.writeto(outfits, overwrite=True)
-    
+
     printStatus.updateDone("Writing: "+config['GENERAL']['RUN_ID']+'_gas-cleaned_'+currentLevel+'.fits')
     logging.info("Wrote: "+outfits)
-   
+
 
     # ========================
     # SAVE WEIGHTS
     if (config['GAS']['LEVEL'] in ['BIN', 'SPAXEL'])  or  \
        (config['GAS']['LEVEL'] == 'BOTH' and currentLevel == 'BIN'):
-           
+
         outfits = os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_gas-weights_'+currentLevel+'.fits'
         printStatus.running("Writing: "+config['GENERAL']['RUN_ID']+'_gas-weights_'+currentLevel+'.fits')
-        
+
         # Primary HDU
         priHDU = fits.PrimaryHDU()
-        
+
         # Extension 1: Table HDU with normalized weights
         cols = []
         cols.append( fits.Column(name='NWEIGHTS', format=str(n_templates)+'D', array=nweights ) )
         dataHDU = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
         dataHDU.name = 'NWEIGHTS'
-    
+
         # Extension 2: Table HDU with weights of emission-lines
         cols = []
         cols.append( fits.Column(name='EWEIGHTS', format=str(emission_weights.shape[1])+'D', array=emission_weights ) )
         eweightsHDU = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
         eweightsHDU.name = 'EWEIGHTS'
-         
+
         # Create HDU list and write to file
         priHDU      = _auxiliary.saveConfigToHeader(priHDU, config['GAS'])
         dataHDU     = _auxiliary.saveConfigToHeader(dataHDU, config['GAS'])
@@ -270,7 +270,7 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 
         HDUList = fits.HDUList([priHDU, dataHDU, eweightsHDU])
         HDUList.writeto(outfits, overwrite=True)
-        
+
         printStatus.updateDone("Writing: "+config['GENERAL']['RUN_ID']+'_gas-weights_'+currentLevel+'.fits')
         logging.info("Wrote: "+outfits)
 
@@ -280,22 +280,22 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
     if currentLevel == 'BIN':
         outfits = os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_gas-optimalTemplate_'+currentLevel+'.fits'
         printStatus.running("Writing: "+config['GENERAL']['RUN_ID']+'_gas-optimalTemplate_'+currentLevel+'.fits')
-        
+
         # Primary HDU
         priHDU = fits.PrimaryHDU()
-        
+
         # Extension 1: Table HDU with optimal templates
         cols = []
         cols.append( fits.Column(name='OPTIMAL_TEMPLATE', format=str(optimal_template.shape[1])+'D', array=optimal_template ) )
         dataHDU = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
         dataHDU.name = 'OPTIMAL_TEMPLATE'
-    
+
         # Extension 2: Table HDU with logLam_templates
         cols = []
         cols.append( fits.Column(name='LOGLAM_TEMPLATE', format='D', array=logLam_template) )
         logLamHDU = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
         logLamHDU.name = 'LOGLAM_TEMPLATE'
-        
+
         # Create HDU list and write to file
         priHDU    = _auxiliary.saveConfigToHeader(priHDU, config['GAS'])
         dataHDU   = _auxiliary.saveConfigToHeader(dataHDU, config['GAS'])
@@ -303,7 +303,7 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 
         HDUList = fits.HDUList([priHDU, dataHDU, logLamHDU])
         HDUList.writeto(outfits, overwrite=True)
-        
+
         printStatus.updateDone("Writing: "+config['GENERAL']['RUN_ID']+'_gas-optimalTemplate_'+currentLevel+'.fits')
         logging.info("Wrote: "+outfits)
 
@@ -311,7 +311,7 @@ def save_gandalf(config, emission_setup, idx_l, sol, esol, nlines, sol_gas_AoN,\
 def getGoodpixelsEmissionSetup(config, redshift, velscale, logLam_galaxy, logLam_template, npix):
     """
     Reads information about the emission-lines from the emissionLines.config
-    file, in order to 
+    file, in order to
      * determine which spectral regions are masked in the GandALF fit
      * create a structure which states details on the intended emission-line
        fits
@@ -338,8 +338,8 @@ def getGoodpixelsEmissionSetup(config, redshift, velscale, logLam_galaxy, logLam
 
     # Prepare emission_setup structure for GANDALF, which should only deal with the lines we fit
     i_f = []
-    for itm in np.arange(len(emission_setup)): 
-        if (emission_setup[itm].action != 'f'): 
+    for itm in np.arange(len(emission_setup)):
+        if (emission_setup[itm].action != 'f'):
             i_f.append(itm)
     emission_setup = [v for i,v in enumerate(emission_setup) if i not in frozenset(i_f)]
 
@@ -371,7 +371,7 @@ def performEmissionLineAnalysis(config):
         raise Exception(message)
 
     # For output filenames
-    if config['GAS']['LEVEL'] in ['BIN', 'SPAXEL']: 
+    if config['GAS']['LEVEL'] in ['BIN', 'SPAXEL']:
         currentLevel = config['GAS']['LEVEL']
     elif config['GAS']['LEVEL'] == 'BOTH'  and  os.path.isfile(os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+"_gas_BIN.fits") == False:
         currentLevel = 'BIN'
@@ -382,8 +382,8 @@ def performEmissionLineAnalysis(config):
     velscale_ratio = 2
 
     # Read LSF information
-    LSF_Data, LSF_Templates = _auxiliary.getLSF(config)
-       
+    LSF_Data, LSF_Templates = _auxiliary.getLSF(config, 'GAS')
+
     # Read data if we run on BIN level
     if currentLevel == 'BIN':
         # Read spectra from file
@@ -400,16 +400,16 @@ def performEmissionLineAnalysis(config):
         # Create empty mask in bin-level run: There are no masked bins, only masked spaxels!
         maskedSpaxel    = np.zeros(nbins, dtype=bool)
         maskedSpaxel[:] = False
-    
+
         # Prepare templates
         logging.info("Using full spectral library for GANDALF on BIN level")
         templates, lamRange_spmod, logLam_template, n_templates = \
-                _prepareTemplates.prepareTemplates_Module(config, config['GAS']['LMIN'], config['GAS']['LMAX'], velscale/velscale_ratio, LSF_Data, LSF_Templates)[:4]
+                _prepareTemplates.prepareTemplates_Module(config, config['GAS']['LMIN'], config['GAS']['LMAX'], velscale/velscale_ratio, LSF_Data, LSF_Templates, 'GAS')[:4]
         templates = templates.reshape( (templates.shape[0], n_templates) )
-        
+
         offset       = (logLam_template[0] - logLam_galaxy[0])*C # km/s
         error        = np.ones((npix,nbins))
-   
+
         # Read stellar kinematics from file
         ppxf = fits.open(os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_kin.fits')[1].data
         stellar_kin = np.zeros((ppxf.V.shape[0],6))
@@ -417,7 +417,7 @@ def performEmissionLineAnalysis(config):
         stellar_kin[:,1] = np.array(ppxf.SIGMA)
         if hasattr(ppxf, 'H3'): stellar_kin[:,2] = np.array(ppxf.H3)
         if hasattr(ppxf, 'H4'): stellar_kin[:,3] = np.array(ppxf.H4)
-    
+
         # Rename to keep the code clean
         for_errors = config['GAS']['ERRORS']
 
@@ -440,12 +440,12 @@ def performEmissionLineAnalysis(config):
         maskedSpaxel = np.array(mask, dtype=bool)
 
         # Prepare templates
-        if config['GAS']['LEVEL'] == 'SPAXEL': 
+        if config['GAS']['LEVEL'] == 'SPAXEL':
             logging.info("Using full spectral library for GANDALF on SPAXEL level")
             templates, lamRange_spmod, logLam_template, n_templates = \
                     _prepareTemplates.prepareTemplates_Module(config, config['GAS']['LMIN'], config['GAS']['LMAX'], velscale/velscale_ratio, LSF_Data, LSF_Templates)[:4]
             templates = templates.reshape( (templates.shape[0], n_templates) )
-        if config['GAS']['LEVEL'] == 'BOTH': 
+        if config['GAS']['LEVEL'] == 'BOTH':
             logging.info("Using previously extracted optimal templates from the GANDALF BIN level on SPAXEL level")
             hdu             = fits.open(os.path.join(config['GENERAL']['OUTPUT'],config['GENERAL']['RUN_ID'])+'_gas-optimalTemplate_BIN.fits')
             templates       = np.array( hdu[1].data.OPTIMAL_TEMPLATE.T )
@@ -490,7 +490,7 @@ def performEmissionLineAnalysis(config):
     if (config['GAS']['EBmV'] != None):
         dereddening_attenuation = gandalf.dust_calzetti\
                 (logLam_galaxy[0], logLam_galaxy[1]-logLam_galaxy[0], npix, -1*config['GAS']['EBmV'], 0.0, 0)
-        for i in range( spectra.shape[1] ): 
+        for i in range( spectra.shape[1] ):
             spectra[:,i] = spectra[:,i]*dereddening_attenuation
 
     # Get goodpixels and emission_setup
@@ -501,12 +501,12 @@ def performEmissionLineAnalysis(config):
     for itm in np.arange( len(emission_setup) ):
         if emission_setup[itm].action == 'f' and emission_setup[itm].kind == 'l': nlines += 1
 
-    if config['GAS']['REDDENING'] == False: 
+    if config['GAS']['REDDENING'] == False:
         reddening = None
         mdegree = config['GAS']['MDEG']
         reddening_length_sol  = config['GAS']['MDEG']
-        reddening_length_esol = 0 
-    else: 
+        reddening_length_esol = 0
+    else:
         reddening = [ float(config['GAS']['REDDENING'].split(',')[0].strip()), float(config['GAS']['REDDENING'].split(',')[1].strip()) ]
         mdegree = 0
         reddening_length_sol  = 2
@@ -530,33 +530,33 @@ def performEmissionLineAnalysis(config):
     if config['GENERAL']['PARALLEL'] == True:
         printStatus.running("Running GANDALF in parallel mode")
         logging.info("Running GANDALF in parallel mode")
-       
+
         # Create Queues
         inQueue  = Queue()
         outQueue = Queue()
-    
+
         # Create worker processes
         ps = [Process(target=workerGANDALF, args=(inQueue, outQueue))
               for _ in range(config['GENERAL']['NCPU'])]
-    
+
         # Start worker processes
         for p in ps: p.start()
-    
+
         # Fill the queue
-        if n_templates > 1: 
+        if n_templates > 1:
             for i in range(nbins):
                 inQueue.put( ( spectra[:,i], error[:,i], stellar_kin[i,:], templates, logLam_galaxy, logLam_template, \
                                config['GAS']['EMI_FILE'], 0.0, velscale, int_disp, reddening, mdegree,\
                                for_errors, offset, velscale_ratio, i, nbins, npix, config, maskedSpaxel[i] ) )
-        elif n_templates == 1: 
+        elif n_templates == 1:
             for i in range(nbins):
                 inQueue.put( ( spectra[:,i], error[:,i], stellar_kin[i,:], templates[[i],:].T, logLam_galaxy, logLam_template, \
                                config['GAS']['EMI_FILE'], 0.0, velscale, int_disp, reddening, mdegree,\
                                for_errors, offset, velscale_ratio, i, nbins, npix, config, maskedSpaxel[i] ) )
-     
+
         # now get the results with indices
         gandalf_tmp = [outQueue.get() for _ in range(nbins)]
-    
+
         # send stop signal to stop iteration
         for _ in range(config['GENERAL']['NCPU']): inQueue.put('STOP')
 
@@ -579,19 +579,19 @@ def performEmissionLineAnalysis(config):
         bestfit            = bestfit[argidx,:]
         sol                = sol[argidx,:]
         esol               = esol[argidx,:]
-        
+
         printStatus.updateDone("Running GANDALF in parallel mode", progressbar=True)
 
     elif config['GENERAL']['PARALLEL'] == False:
         printStatus.running("Running GANDALF in serial mode")
         logging.info("Running GANDALF in serial mode")
-        if n_templates > 1: 
+        if n_templates > 1:
             for i in range(0, nbins):
                 weights[i,:], emission_templates[i,:,:], bestfit[i,:], sol[i,:], esol[i,:] = run_gandalf\
                   (spectra[:,i], error[:,i], stellar_kin[i,:], templates, logLam_galaxy, logLam_template, \
                   config['GAS']['EMI_FILE'], 0.0, velscale, int_disp, reddening, mdegree,\
                   for_errors, offset, velscale_ratio, i, nbins, npix, config, maskedSpaxel[i] )
-        elif n_templates == 1: 
+        elif n_templates == 1:
             for i in range(0, nbins):
                 weights[i,:], emission_templates[i,:,:], bestfit[i,:], sol[i,:], esol[i,:] = run_gandalf\
                   (spectra[:,i], error[:,i], stellar_kin[i,:], templates[[i],:].T, logLam_galaxy, logLam_template, \
@@ -632,7 +632,7 @@ def performEmissionLineAnalysis(config):
            (config['GAS']['LEVEL'] == 'BOTH' and currentLevel == 'BIN'):
             # Make the unconvolved optimal stellar template
             nweights[i,:] = weights[i,:n_templates] / np.sum(weights[i,:n_templates])
-            for j in range(0,n_templates): 
+            for j in range(0,n_templates):
                 optimal_template[i,:] = optimal_template[i,:] + templates[:,j]*nweights[i,j]
 
         # Calculate emission-subtracted spectra using a AoN threshold
@@ -650,11 +650,9 @@ def performEmissionLineAnalysis(config):
             nweights, weights[:,n_templates:], for_errors, npix, n_templates, bestfit, emissionSpectrum, reddening, currentLevel)
 
     # Restart GANDALF if a SPAXEL level run based on a previous BIN level run is intended
-    if config['GAS']['LEVEL'] == 'BOTH'  and  currentLevel == 'BIN': 
+    if config['GAS']['LEVEL'] == 'BOTH'  and  currentLevel == 'BIN':
         print()
         performEmissionLineAnalysis(config)
 
     # Return
     return(None)
-
-

--- a/gistPipeline/prepareTemplates/_prepareTemplates.py
+++ b/gistPipeline/prepareTemplates/_prepareTemplates.py
@@ -6,19 +6,19 @@ from printStatus import printStatus
 
 
 
-def prepareTemplates_Module(config, lmin, lmax, velscale, LSF_Data, LSF_Templates, sortInGrid=False):
+def prepareTemplates_Module(config, lmin, lmax, velscale, LSF_Data, LSF_Templates, module_used, sortInGrid=False):
     """
-    This function calls the prepareTemplates routine specified by the user. 
+    This function calls the prepareTemplates routine specified by the user.
     """
     # Import the chosen prepareTemplates routine
     try:
-        spec = importlib.util.spec_from_file_location("",os.path.dirname(os.path.realpath(__file__))+"/"+config['PREPARE_TEMPLATES']['METHOD']+".py")
-        logging.info("Using the routine for '"+config['PREPARE_TEMPLATES']['METHOD']+".py'")
+        spec = importlib.util.spec_from_file_location("",os.path.dirname(os.path.realpath(__file__))+"/"+config[module_used]['TEMPLATE_SET']+".py")
+        logging.info("Using the routine for '"+config[module_used]['TEMPLATE_SET']+".py'")
         prepTemplatesModule = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(prepTemplatesModule)
     except Exception as e:
         logging.critical(e, exc_info=True)
-        message = "Failed to import the routine '"+config['PREPARE_TEMPLATES']['METHOD']+".py'"
+        message = "Failed to import the routine '"+config[module_used]['TEMPLATE_SET']+".py'"
         printStatus.failed(message)
         logging.critical(message)
         return("SKIP")
@@ -26,15 +26,13 @@ def prepareTemplates_Module(config, lmin, lmax, velscale, LSF_Data, LSF_Template
     # Execute the chosen prepareTemplates routine
     try:
         templates, lamRange_spmod, logLam2, ntemplates, logAge_grid, metal_grid, alpha_grid, ncomb, nAges, nMetal, nAlpha = \
-                prepTemplatesModule.prepareSpectralTemplateLibrary(config, lmin, lmax, velscale, LSF_Data, LSF_Templates, sortInGrid)
+                prepTemplatesModule.prepareSpectralTemplateLibrary(config, lmin, lmax, velscale, LSF_Data, LSF_Templates, module_used, sortInGrid)
     except Exception as e:
         logging.critical(e, exc_info=True)
-        message = "Routine '"+config['PREPARE_TEMPLATES']['METHOD']+".py' failed."
+        message = "Routine '"+config[module_used]['TEMPLATE_SET']+".py' failed."
         printStatus.failed(message)
         logging.critical(message)
         return("SKIP")
 
     # Return
     return(templates, lamRange_spmod, logLam2, ntemplates, logAge_grid, metal_grid, alpha_grid, ncomb, nAges, nMetal, nAlpha)
-
-

--- a/gistPipeline/stellarKinematics/_stellarKinematics.py
+++ b/gistPipeline/stellarKinematics/_stellarKinematics.py
@@ -10,12 +10,12 @@ from gistPipeline.plotting import _plotting
 
 def stellarKinematics_Module(config):
     """
-    This function calls the stellarKinematics routine specified by the user. 
+    This function calls the stellarKinematics routine specified by the user.
     """
     printStatus.module("stellarKinematics module")
 
     # Check if module is turned off in MasterConfig
-    if config['KIN']['METHOD'] == False: 
+    if config['KIN']['METHOD'] == False:
         message = "The module was turned off."
         printStatus.warning(message)
         logging.warning(message)
@@ -26,8 +26,8 @@ def stellarKinematics_Module(config):
     if config['GENERAL']['OW_OUTPUT'] == False  and  \
             os.path.isfile(outPrefix+"_kin.fits") == True  and \
             os.path.isfile(outPrefix+"_kin-bestfit.fits") == True  and  \
-            os.path.isfile(outPrefix+"_kin-optimalTemplates.fits") == True: 
-        logging.info("Results of the module are already in the output directory. Module is skipped.") 
+            os.path.isfile(outPrefix+"_kin-optimalTemplates.fits") == True:
+        logging.info("Results of the module are already in the output directory. Module is skipped.")
         printStatus.done("Results are already available. Module is skipped.")
         return(None)
 
@@ -54,8 +54,6 @@ def stellarKinematics_Module(config):
         printStatus.failed(message+" See LOGFILE for further information.")
         logging.critical(message)
         return("SKIP")
- 
+
     # Return
     return(None)
-
-

--- a/gistPipeline/stellarKinematics/ppxf.py
+++ b/gistPipeline/stellarKinematics/ppxf.py
@@ -341,7 +341,7 @@ def extractStellarKinematics(config):
     velscale = hdu[0].header['VELSCALE']
 
     # Read LSF information
-    LSF_Data, LSF_Templates = _auxiliary.getLSF(config)
+    LSF_Data, LSF_Templates = _auxiliary.getLSF(config, 'KIN') # added input of module 
 
     # Prepare templates
     velscale_ratio = 2

--- a/gistPipeline/stellarKinematics/ppxf.py
+++ b/gistPipeline/stellarKinematics/ppxf.py
@@ -347,7 +347,7 @@ def extractStellarKinematics(config):
     velscale_ratio = 2
     logging.info("Using full spectral library for PPXF")
     templates, lamRange_spmod, logLam_template, ntemplates = _prepareTemplates.prepareTemplates_Module\
-            (config, config['KIN']['LMIN'], config['KIN']['LMAX'], velscale/velscale_ratio, LSF_Data, LSF_Templates)[:4]
+            (config, config['KIN']['LMIN'], config['KIN']['LMAX'], velscale/velscale_ratio, LSF_Data, LSF_Templates, 'KIN')[:4]
     templates = templates.reshape( (templates.shape[0], ntemplates) )
 
     # Last preparatory steps

--- a/gistTutorial/configFiles/MasterConfig.yaml
+++ b/gistTutorial/configFiles/MasterConfig.yaml
@@ -1,4 +1,5 @@
 # This is a test config file
+# AMELIA don't use this one!!!
 GENERAL :
   RUN_ID : 'NGC0000Example' # Name of the analysis run. A subdirectory of this name within the output directory will be created. This identifier further serves as a prefix to all output files.
   INPUT : 'NGC0000.fits' # Input file for this analysis run. The specified path is relative to the input path given in defaultDir.
@@ -7,7 +8,6 @@ GENERAL :
   PARALLEL: True # Use multiprocessing [True/False]
   NCPU : 4 # Number of cores to use for multiprocessing
   LSF_DATA : 'lsf_MUSE-WFM' # Path of the file specifying the line-spread-function of the observational data. The specified path is relative to the configDir path in defaultDir.
-  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
   OW_CONFIG : True #  Ignore configurations from previous runs which are saved in the CONFIG file in the output directory [True/False]
   OW_OUTPUT : True # Overwrite any output files already present in the current output directory [True/False]
 
@@ -17,7 +17,7 @@ READ_DATA :
   DEBUG : FALSE # Switch to activate debug mode [True/False]: Pipeline runs on one, central line of pixels. Keep in mind to clean output directory after running in DEBUG mode!
   ORIGIN : 14,14 # Origin of the coordinate system in pixel coordinates: x,y (Indexing starts at 0).
   LMIN_TOT : 4800 # Spectra are shortened to the rest-frame wavelength range defined by LMIN_TOT and LMAX_TOT. Note that this wavelength range should be longer than all other wavelength ranges supplied to the modules [in Angst.]
-  LMAX_TOT : 5500
+  LMAX_TOT : 6900
   LMIN_SNR : 4800 # Rest-frame wavelength range used for the signal-to-noise calculation [in Angst.]
   LMAX_SNR : 5500
 
@@ -39,39 +39,45 @@ PREPARE_SPECTRA :
   METHOD : 'default'
   VELSCALE : 70
 
-# Prepare templates module
-PREPARE_TEMPLATES :
-  METHOD : 'miles'
-  LIBRARY : 'MILES/'
-  NORM_TEMP : 'LIGHT'
+# # Prepare templates module
+# PREPARE_TEMPLATES :
+
 
 # Stellar kinematics module
 KIN :
-  METHOD : 'ppxf'
+  METHOD : 'ppxf' # Options: 'ppxf' or False
   SPEC_MASK : 'specMask_KIN'
   LMIN : 4800
-  LMAX : 5500
+  LMAX : 6900
   SIGMA : 200
   MOM : 4
   ADEG : 8
   MDEG : 0
   REDDENING : null # As opposed to None
   MC_PPXF : 0
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  METHOD : 'miles' # current options: miles,
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
 
 # Emission line fitting module
 GAS :
-  METHOD : 'gandalf'
+  METHOD : 'gandalf' # Options: 'gandalf' or False
   LEVEL : 'BIN'
   LMIN : 4800
-  LMAX : 5500
+  LMAX : 6900
   ERRORS : 0
   REDDENING : 0.1,0.1
   EBmV : null # As opposed to None
   EMI_FILE : 'emissionLines.config'
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  METHOD : 'miles' # current options: miles,
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
 
 # Star formation histories module
 SFH :
-  METHOD : 'ppxf'
+  METHOD : 'ppxf' # Options: 'ppxf' or False
   LMIN : 4800
   LMAX : 5500
   SPEC_MASK : 'specMask_SFH'
@@ -80,10 +86,14 @@ SFH :
   REGUL_ERR : 1.
   NOISE : 1.
   FIXED : True
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  METHOD : 'miles' # current options: miles,
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'
 
 # Line strenghts module
 LS :
-  METHOD : 'default'
+  METHOD : 'default' # Options: 'default' or False
   TYPE : 'SPP'
   LS_FILE : 'lsBands.config'
   CONV_COR : 8.4
@@ -91,3 +101,7 @@ LS :
   MC_LS : 30
   NWALKER : 10
   NCHAIN : 100
+  LSF_TEMP : 'lsf_MILES' # Path of the file specifying the line-spread-function of the spectral templates. The specified path is relative to the configDir path in defaultDir.
+  METHOD : 'miles' # current options: miles,
+  LIBRARY : 'MILES/'
+  NORM_TEMP : 'LIGHT'


### PR DESCRIPTION
Implemented the option for different template libraries for different modules. Now, you need to specify the template set used for each module (stellar kinematics, emission lines, stellar populations, line strengths). In practise, we will probably use the same template set for the last three. The config yaml file has been updated to reflect this change, and this is a breaking change.