### PR TITLE
Implement write FITS with celestial WCS 

### DIFF
--- a/gistPipeline/plotting/save_maps_fits.py
+++ b/gistPipeline/plotting/save_maps_fits.py
@@ -78,9 +78,7 @@ def savefitsmaps(flag, outdir):
         image = np.full( (npixels_x, npixels_y), np.nan )
         
         # Reverse the index to flip the image
-        # since WCS transformations - like FITS files - assume
-        # that the origin is the lower left pixel of the image 
-        # (origin is in top left for numpy arrays)
+        # since ra increases left to right 
         image[i[::-1], j] = val
 
         # Transpose x and y because numpy uses arr[row, col] and FITS uses 
@@ -153,9 +151,7 @@ def savefitsmaps_LSmodule(flag, outdir, RESOLUTION):
         image = np.full( (npixels_x, npixels_y), np.nan )
         
         # Reverse the index to flip the image
-        # since WCS transformations - like FITS files - assume
-        # that the origin is the lower left pixel of the image 
-        # (origin is in top left for numpy arrays)
+        # since ra increases left to right 
         image[i[::-1], j] = val
 
         # Transpose x and y because numpy uses arr[row, col] and FITS uses 

--- a/gistPipeline/plotting/save_maps_fits.py
+++ b/gistPipeline/plotting/save_maps_fits.py
@@ -77,8 +77,8 @@ def savefitsmaps(flag, outdir):
         j = np.array( np.round( (Y - ymin)/pixelsize ), dtype=np.int32 )
         image = np.full( (npixels_x, npixels_y), np.nan )
         
-        # Reverse the index to flip the image
-        # since ra increases left to right 
+        # Reverse the i index to each row of the image
+        # because ra increases West-East (right-left in image plane)
         image[i[::-1], j] = val
 
         # Transpose x and y because numpy uses arr[row, col] and FITS uses 
@@ -150,11 +150,11 @@ def savefitsmaps_LSmodule(flag, outdir, RESOLUTION):
         j = np.array( np.round( (Y - ymin)/pixelsize ), dtype=np.int32 )
         image = np.full( (npixels_x, npixels_y), np.nan )
         
-        # Reverse the index to flip the image
-        # since ra increases left to right 
+        # Reverse the i index to each row of the image
+        # because ra increases West-East (right-left in image plane)
         image[i[::-1], j] = val
 
-        # Transpose x and y because numpy uses arr[row, col] and FITS uses 
+        # Transpose x and y to reorient the image correctly
         # im[ra, dec] = arr[col, row]
         image = image.T
         

--- a/gistPipeline/plotting/save_maps_fits.py
+++ b/gistPipeline/plotting/save_maps_fits.py
@@ -6,14 +6,7 @@ import os
 import optparse
 import warnings
 warnings.filterwarnings('ignore')
-from matplotlib.tri import Triangulation, TriAnalyzer
 
-import matplotlib.pyplot       as     plt
-from   mpl_toolkits.axes_grid1 import AxesGrid
-from   matplotlib.ticker       import MultipleLocator, FuncFormatter
-
-from plotbin.sauron_colormap import register_sauron_colormap
-register_sauron_colormap()
 
 def savefitsmaps(flag, outdir):
 
@@ -83,7 +76,18 @@ def savefitsmaps(flag, outdir):
         i = np.array( np.round( (X - xmin)/pixelsize ), dtype=np.int32 )
         j = np.array( np.round( (Y - ymin)/pixelsize ), dtype=np.int32 )
         image = np.full( (npixels_x, npixels_y), np.nan )
-        image[i,j] = val
+        
+        # Reverse the index to flip the image
+        # since WCS transformations - like FITS files - assume
+        # that the origin is the lower left pixel of the image 
+        # (origin is in top left for numpy arrays)
+        image[i[::-1], j] = val
+
+        # Transpose x and y because numpy uses arr[row, col] and FITS uses 
+        # im[ra, dec] = arr[col, row]
+        image = image.T
+
+        # make HDU
         image_hdu = fits.ImageHDU(image, header=wcshdr, name=names[iterate])
         # Append fits image
         hdu1.append(image_hdu)
@@ -135,6 +139,7 @@ def savefitsmaps_LSmodule(flag, outdir, RESOLUTION):
     primary_hdu = fits.PrimaryHDU()
     hdu1 = fits.HDUList([primary_hdu])
     names = labellist
+    
     for iterate in range(0,len(names)):
         # Prepare main plot
         val = result[:,iterate]
@@ -146,7 +151,18 @@ def savefitsmaps_LSmodule(flag, outdir, RESOLUTION):
         i = np.array( np.round( (X - xmin)/pixelsize ), dtype=np.int32 )
         j = np.array( np.round( (Y - ymin)/pixelsize ), dtype=np.int32 )
         image = np.full( (npixels_x, npixels_y), np.nan )
-        image[i,j] = val
+        
+        # Reverse the index to flip the image
+        # since WCS transformations - like FITS files - assume
+        # that the origin is the lower left pixel of the image 
+        # (origin is in top left for numpy arrays)
+        image[i[::-1], j] = val
+
+        # Transpose x and y because numpy uses arr[row, col] and FITS uses 
+        # im[ra, dec] = arr[col, row]
+        image = image.T
+        
+        # make HDU
         image_hdu = fits.ImageHDU(image, header=wcshdr, name=names[iterate])
         # Append fits image
         hdu1.append(image_hdu)


### PR DESCRIPTION
Initial PR where saved FITS images have correct WCS.

This PR modifies the save_maps_fits routine to
1.  Reverse the i index of each row in the numpy array because ra increases West-East (right-left in image plane / numpy array)
2. Transpose x-y in image to orientate correctly in WCS RA-Dec.

Merging into dev branch right now and will test properly before merging into master.