### PR TITLE
Gas module cleanup, added feature to spatial masking module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@
 ------------------------------------------------------------------------------------------
 VERSION    DATE          DESCRIPTION
 ------------------------------------------------------------------------------------------
+V7.6.7      2026-01-30 FIXED: correct outputs for gas BOTH mode in ppxf_gas_wrapper. 
+		    ADDED: keyword THRESHOLD_METHOD: 'isophote' as default, 'actual', 'smooth'
+		    in spatial masking module.
+
 V7.6.6      2026-01-29 FIXED: general code, with cleanup of redundant keywords. Added 
 		    option in spatial_binning for no binning next to voronoi binning. 
 			ADDED: galactic extinction correction to all MUSE read modules, and corrected 
@@ -16,7 +20,7 @@ V7.6.6      2026-01-29 FIXED: general code, with cleanup of redundant keywords. 
 		    check for template wavelength range being larger than galaxy wavelength range						
 			CHANGED: emissionLines.config and emissionLinesPHANGS.config renamed to 
 		    emissionLines_gandalf.config and emissionLines_ppxf.config. Gas module 
-		    REDDENING keyword changed to dust_corr. 
+		    REDDENING keyword changed to DUST_CORR. 
 
 V7.6.5	    2026-01-28 ADDED functionality for SAMI and MaNGA. These are in beta testing.
 	       Please do not use these without speaking to the developers!

--- a/ngistPipeline/_version.py
+++ b/ngistPipeline/_version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "7.6.6"
+__version__ = "7.6.7"

--- a/ngistPipeline/emissionLines/_emissionLines.py
+++ b/ngistPipeline/emissionLines/_emissionLines.py
@@ -106,8 +106,8 @@ def emissionLines_Module(config):
     # Execute the chosen emissionLines routine
     try:
         module.performEmissionLineAnalysis(config)
-        if config["GAS"]["LEVEL"] == "BOTH": # rerun emission line module for the spaxel products
-            module.performEmissionLineAnalysis(config)
+        #if config["GAS"]["LEVEL"] == "BOTH": # rerun emission line module for the spaxel products
+        #    module.performEmissionLineAnalysis(config)
         _writeFITS.generateFITS(config, "GAS") #Then move on to saving results as usual
     except Exception as e:
         logging.critical(e, exc_info=True)

--- a/ngistPipeline/emissionLines/gandalf_gas_wrapper.py
+++ b/ngistPipeline/emissionLines/gandalf_gas_wrapper.py
@@ -1114,7 +1114,8 @@ def performEmissionLineAnalysis(config):
 
     # Calculate the best fitting emission
     emissionSpectrum = np.sum(emission_templates, axis=2)
-    emissionSubtractedBestfit = bestfit - emissionSpectrum
+    # not being used at the moment?
+    #emissionSubtractedBestfit = bestfit - emissionSpectrum
 
     # Save results to file
     save_gandalf(

--- a/ngistPipeline/emissionLines/ppxf_gas_wrapper.py
+++ b/ngistPipeline/emissionLines/ppxf_gas_wrapper.py
@@ -1094,87 +1094,92 @@ def performEmissionLineAnalysis(config):  # This is your main emission line fitt
     sigma_final_measured = (sigma_final**2 + templates_sigma**2) ** (0.5)
 
     # save results to file
-    if config["GAS"]["LEVEL"] != "BOTH":
-        save_ppxf_emlines(
-            config,
-            config["GENERAL"]["OUTPUT"],
-            config["GENERAL"]["RUN_ID"],
-            config["GAS"]["LEVEL"],
-            linesfitted,
-            gas_flux_in_units,
-            gas_err_flux_in_units,
-            vel_final,
-            vel_err_final,
-            sigma_final_measured,
-            sigma_err_final,
-            chi2,
-            templates_sigma,
-            bestfit,
-            gas_bestfit,
-            stkin,
-            spectra,
-            error,
-            goodPixels_gas,
-            logLam_galaxy,
-            ubins,
-            npix,
-            extra,
-        )
 
-    if (
-        config["GAS"]["LEVEL"] == "BOTH"
-    ):  # Special case when wanting the gas in bin and spaxel modes
-        save_ppxf_emlines(
-            config,
-            config["GENERAL"]["OUTPUT"],
-            config["GENERAL"]["RUN_ID"],
-            "BIN",
-            linesfitted,
-            gas_flux_in_units,
-            gas_err_flux_in_units,
-            vel_final,
-            vel_err_final,
-            sigma_final_measured,
-            sigma_err_final,
-            chi2,
-            templates_sigma,
-            bestfit,
-            gas_bestfit,
-            stkin,
-            spectra,
-            error,
-            goodPixels_gas,
-            logLam_galaxy,
-            ubins,
-            npix,
-            extra,
-        )
+    save_ppxf_emlines(
+        config,
+        config["GENERAL"]["OUTPUT"],
+        config["GENERAL"]["RUN_ID"],
+        currentLevel,
+        linesfitted,
+        gas_flux_in_units,
+        gas_err_flux_in_units,
+        vel_final,
+        vel_err_final,
+        sigma_final_measured,
+        sigma_err_final,
+        chi2,
+        templates_sigma,
+        bestfit,
+        gas_bestfit,
+        stkin,
+        spectra,
+        error,
+        goodPixels_gas,
+        logLam_galaxy,
+        ubins,
+        npix,
+        extra,
+    )
 
-        save_ppxf_emlines(
-            config,
-            config["GENERAL"]["OUTPUT"],
-            config["GENERAL"]["RUN_ID"],
-            "SPAXEL",
-            linesfitted,
-            gas_flux_in_units,
-            gas_err_flux_in_units,
-            vel_final,
-            vel_err_final,
-            sigma_final_measured,
-            sigma_err_final,
-            chi2,
-            templates_sigma,
-            bestfit,
-            gas_bestfit,
-            stkin,
-            spectra,
-            error,
-            goodPixels_gas,
-            logLam_galaxy,
-            ubins,
-            npix,
-            extra,
-        )
+ #   if (
+ #       config["GAS"]["LEVEL"] == "BOTH"
+ #   ):  # Special case when wanting the gas in bin and spaxel modes
+ #       save_ppxf_emlines(
+ #           config,
+ #           config["GENERAL"]["OUTPUT"],
+ #           config["GENERAL"]["RUN_ID"],
+ #           "BIN",
+ #           linesfitted,
+ #           gas_flux_in_units,
+ #           gas_err_flux_in_units,
+ #           vel_final,
+ #           vel_err_final,
+ #           sigma_final_measured,
+ #           sigma_err_final,
+ #           chi2,
+ #           templates_sigma,
+ #           bestfit,
+ #           gas_bestfit,
+ #           stkin,
+ #           spectra,
+ #           error,
+ #           goodPixels_gas,
+ #           logLam_galaxy,
+ #           ubins,
+ #           npix,
+ #           extra,
+ #       )
+#
+ #       save_ppxf_emlines(
+ #           config,
+ #           config["GENERAL"]["OUTPUT"],
+ #           config["GENERAL"]["RUN_ID"],
+ #           "SPAXEL",
+ #           linesfitted,
+ #           gas_flux_in_units,
+ #           gas_err_flux_in_units,
+ #           vel_final,
+ #           vel_err_final,
+ #           sigma_final_measured,
+ #           sigma_err_final,
+ #           chi2,
+ #           templates_sigma,
+ #           bestfit,
+ #           gas_bestfit,
+ #           stkin,
+ #           spectra,
+ #           error,
+ #           goodPixels_gas,
+ #           logLam_galaxy,
+ #           ubins,
+ #           npix,
+ #           extra,
+ #       )
+
+    # Restart pPPXF if a SPAXEL level run based on a previous BIN level run is intended
+    if config["GAS"]["LEVEL"] == "BOTH" and currentLevel == "BIN":
+        print()
+        performEmissionLineAnalysis(config)
 
     printStatus.updateDone("Emission line fitting done")
     # print("")

--- a/ngistPipeline/spatialMasking/default.py
+++ b/ngistPipeline/spatialMasking/default.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 from astropy.io import fits
 from printStatus import printStatus
+from scipy.ndimage import gaussian_filter
 
 
 def generate_spatial_mask(config, cube):
@@ -44,10 +45,14 @@ def generateSpatialMask(config, cube):
 
     # Mask defunct spaxels
     maskedDefunct = maskDefunctSpaxels(cube)
-
+    
     # Mask spaxels with SNR below threshold
+    # check if a specific method is preferred
+    if 'THRESHOLD_METHOD' in config["SPATIAL_MASKING"]:
+        threshold_method  = config["SPATIAL_MASKING"]["THRESHOLD_METHOD"]
+    
     maskedSNR = applySNRThreshold(
-        cube["snr"], cube["signal"], config["SPATIAL_MASKING"]["MIN_SNR"]
+        cube["snr"], cube["signal"], config["SPATIAL_MASKING"]["MIN_SNR"], threshold_method = threshold_method
     )
 
     # Mask spaxels according to spatial mask file
@@ -117,6 +122,19 @@ def applySNRThreshold(snr, signal, min_snr, threshold_method="isophote"):
     if threshold_method == "actual":
         idx_inside = np.where(snr >= min_snr)[0]
         idx_outside = np.where(snr < min_snr)[0]
+
+    if threshold_method == "smooth":
+
+        mask = np.isfinite(snr)
+        snr_filled = np.where(mask, snr, 0.0)
+
+        smoothed_snr = gaussian_filter(snr_filled, sigma=5.0)
+        smoothed_mask = gaussian_filter(mask.astype(float), sigma=5.0)
+
+        smoothed = smoothed_snr / smoothed_mask
+
+        idx_inside = np.where(smoothed >= min_snr)[0]
+        idx_outside = np.where(smoothed < min_snr)[0]        
 
     if len(idx_inside) == 0 and len(idx_outside) == 0:
         idx_inside = np.arange(len(snr))

--- a/ngistPipeline/spatialMasking/default.py
+++ b/ngistPipeline/spatialMasking/default.py
@@ -50,7 +50,9 @@ def generateSpatialMask(config, cube):
     # check if a specific method is preferred
     if 'THRESHOLD_METHOD' in config["SPATIAL_MASKING"]:
         threshold_method  = config["SPATIAL_MASKING"]["THRESHOLD_METHOD"]
-    
+    else:
+        threshold_method  = 'isophote'
+
     maskedSNR = applySNRThreshold(
         cube["snr"], cube["signal"], config["SPATIAL_MASKING"]["MIN_SNR"], threshold_method = threshold_method
     )


### PR DESCRIPTION
V7.6.7      2026-01-30 FIXED: correct outputs for gas BOTH mode in ppxf_gas_wrapper. 
		    ADDED: keyword THRESHOLD_METHOD: 'isophote' as default, 'actual', 'smooth'
		    in spatial masking module.