### PR TITLE
Dev jesse fixbinningissue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,10 +8,10 @@ VERSION    DATE          DESCRIPTION
 ------------------------------------------------------------------------------------------
 V7.6.12     2026-07-27 ADDED: new and updated masking routines. YAML file now takes 
 		    keyword THRESHOLD_METHOD:'isophote', 'isophote_gist' 'actual', 
-			'isophote_smooth', 'actual_smooth'; The old version is isophote_gist. When 
-			calling a smooth version, you can use the SMOOTH_SIGMA keyword to set the
-			size of the Gaussian smoothing. Setting min_snr=0.0 results in all spaxels 
-			being used.
+		    'isophote_smooth', 'actual_smooth'; The old version is isophote_gist. When 
+		    calling a smooth version, you can use the SMOOTH_SIGMA keyword to set the
+		    size of the Gaussian smoothing. Setting min_snr=0.0 results in all spaxels 
+		    being used.
 
 V7.6.11     2026-07-17 ADDED: implementation of the PowerBinning routine by Cappellari 
             (2025) as an alternative to Voronoi binning. 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,8 +6,15 @@
 ------------------------------------------------------------------------------------------
 VERSION    DATE          DESCRIPTION
 ------------------------------------------------------------------------------------------
+V7.6.12     2026-07-27 ADDED: new and updated masking routines. YAML file now takes 
+		    keyword THRESHOLD_METHOD:'isophote', 'isophote_gist' 'actual', 
+			'isophote_smooth', 'actual_smooth'; The old version is isophote_gist. When 
+			calling a smooth version, you can use the SMOOTH_SIGMA keyword to set the
+			size of the Gaussian smoothing. Setting min_snr=0.0 results in all spaxels 
+			being used.
+
 V7.6.11     2026-07-17 ADDED: implementation of the PowerBinning routine by Cappellari 
-                       (2025) as an alternative to Voronoi binning. 
+            (2025) as an alternative to Voronoi binning. 
 
 V7.6.10     2026-07-16 ADDED: new read in modules for miles stars and smiles stars that can 
 		    be used in the SFH module.

--- a/ngistPipeline/_version.py
+++ b/ngistPipeline/_version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "7.6.10"
+__version__ = "7.6.12"

--- a/ngistPipeline/lineStrengths/default.py
+++ b/ngistPipeline/lineStrengths/default.py
@@ -388,9 +388,6 @@ def measureLineStrengths(config, RESOLUTION="ORIGINAL"):
         idx_lamMin = np.where(binned_loglam_data[0] == binned_eloglam_data)[0]
         idx_lamMax = np.where(binned_loglam_data[-1] == binned_eloglam_data)[0]
 
-        print("idx_lamMin:", type(idx_lamMin), np.shape(idx_lamMin), idx_lamMin)
-        print("idx_lamMax:", type(idx_lamMax), np.shape(idx_lamMax), idx_lamMax)
-
         idx_lam = np.arange(idx_lamMin, idx_lamMax + 1)
         oldspec = np.array(binned_spec_data)
         oldespec = np.sqrt(np.array(binned_espec_data)[:, idx_lam])

--- a/ngistPipeline/spatialMasking/default.py
+++ b/ngistPipeline/spatialMasking/default.py
@@ -4,36 +4,7 @@ import os
 import numpy as np
 from astropy.io import fits
 from printStatus import printStatus
-from scipy.ndimage import gaussian_filter
-
-
-def generate_spatial_mask(config, cube):
-    """
-    Generates a spatial mask for the input cube based on defunct spaxels, signal-to-noise ratio threshold,
-    and an additional mask file provided in the configuration.
-
-    Parameters:
-    config (dict): Configuration settings for the spatial masking.
-    cube (dict): Input cube containing 'snr', 'signal', and other necessary data.
-
-    Returns:
-    None
-    """
-    # Mask defunct spaxels
-    masked_defunct = mask_defunct_spaxels(cube)
-
-    # Apply signal-to-noise ratio threshold
-    masked_snr = apply_snr_threshold(cube["snr"], cube["signal"], config["SPATIAL_MASKING"]["MIN_SNR"])
-
-    # Apply additional mask file
-    masked_mask = apply_mask_file(config, cube)
-
-    # Combine all masks
-    combined_mask = np.logical_or.reduce((masked_defunct, masked_snr, masked_mask))
-
-    # Save the combined mask
-    save_mask(combined_mask, masked_defunct, masked_snr, masked_mask, config)
-
+from scipy.ndimage import gaussian_filter, label
 
 def generateSpatialMask(config, cube):
     """
@@ -43,18 +14,21 @@ def generateSpatialMask(config, cube):
     masks spaxels according to a provided mask file. Finally, all masks are combined and saved.
     """
 
-    # Mask defunct spaxels
-    maskedDefunct = maskDefunctSpaxels(cube)
-    
-    # Mask spaxels with SNR below threshold
-    # check if a specific method is preferred
-    if 'THRESHOLD_METHOD' in config["SPATIAL_MASKING"]:
-        threshold_method  = config["SPATIAL_MASKING"]["THRESHOLD_METHOD"]
-    else:
-        threshold_method  = 'isophote'
+    # Mask defunct spaxels if needed
+    maskedDefunct = maskDefunctSpaxels(
+        cube,
+        mask_nan=config["SPATIAL_MASKING"].get("MASK_NAN", True),
+        mask_negative_median=config["SPATIAL_MASKING"].get("MASK_NEGATIVE_MEDIAN", True),
+    )
 
+    # Mask spaxels with SNR below threshold
     maskedSNR = applySNRThreshold(
-        cube["snr"], cube["signal"], config["SPATIAL_MASKING"]["MIN_SNR"], threshold_method = threshold_method
+        cube,
+        cube["snr"], 
+        cube["signal"], 
+        config["SPATIAL_MASKING"]["MIN_SNR"], 
+        config["SPATIAL_MASKING"].get("THRESHOLD_METHOD", "isophote"), 
+        config["SPATIAL_MASKING"].get("SMOOTH_SIGMA", 5.0),
     )
 
     # Mask spaxels according to spatial mask file
@@ -78,28 +52,22 @@ def generateSpatialMask(config, cube):
     # Return
     return None
 
-
-def maskDefunctSpaxels(cube):
+def maskDefunctSpaxels(cube, mask_nan=True,mask_negative_median=True):
     """
-    Mask defunct spaxels, in particular those containing np.nan's or have a
-    negative median.
+    Mask spaxels containing NaNs and/or spaxels with non-positive median flux.
     """
     spec = cube["spec"]
-    
-    # Select defunct spaxels
-    idx_good = np.where(
-        ~np.logical_or(
-            np.any(np.isnan(spec), axis=0),
-            np.nanmedian(spec, axis=0) <= 0.0,
-        )
-    )[0]
 
-    idx_bad = np.where(
-        np.logical_or(
-            np.any(np.isnan(spec), axis=0),
-            np.nanmedian(spec, axis=0) <= 0.0,
-        )
-    )[0]
+    bad_nan = np.any(np.isnan(spec), axis=0) if mask_nan else np.zeros(spec.shape[1], dtype=bool)
+    bad_median = np.nanmedian(spec, axis=0) <= 0.0 if mask_negative_median else np.zeros(spec.shape[1], dtype=bool)
+
+    logging.info(f"NaN spaxels: {np.sum(bad_nan)}")
+    logging.info(f"Negative-median spaxels: {np.sum(bad_median)}")
+
+    bad = np.logical_or(bad_nan, bad_median)
+
+    idx_bad = np.where(bad)[0]
+    idx_good = np.where(~bad)[0]
 
     logging.info(
         "Masking defunct spaxels: " + str(len(idx_bad)) + " spaxels are rejected."
@@ -110,33 +78,164 @@ def maskDefunctSpaxels(cube):
 
     return masked
 
-def applySNRThreshold(snr, signal, min_snr, threshold_method="isophote"):
+def build_spatial_grid(cube, decimals=10):
+    """
+    Build the 2D spatial indexing from flattened spaxel coordinates.
+    Returns x/y coordinate grids and the 1D->2D index mapping.
+    """
+    x = np.round(cube["x"], decimals)
+    y = np.round(cube["y"], decimals)
+
+    x_vals = np.unique(x)
+    y_vals = np.unique(y)
+
+    ix = np.searchsorted(x_vals, x)
+    iy = np.searchsorted(y_vals, y)
+
+    return x_vals, y_vals, ix, iy
+
+
+def values_to_2d(values, x_vals, y_vals, ix, iy, fill_value=np.nan):
+    """
+    Place a flattened spaxel vector onto its 2D spatial grid.
+    """
+    arr_2d = np.full((y_vals.size, x_vals.size), fill_value, dtype=float)
+    arr_2d[iy, ix] = values
+    return arr_2d
+
+def applySNRThreshold(cube, snr, signal, min_snr, threshold_method, smooth_sigma):
     """
     Mask those spaxels that are above the isophote level with a mean
     signal-to-noise ratio of MIN_SNR.
     """
-    if threshold_method == "isophote":
+    if threshold_method == "isophote_gist":
+        # this is the old gist way of creating a mask, but does not work with low S/N
         idx_snr = np.where(np.abs(snr - min_snr) < 2.0)[0]
         meanmin_signal = np.mean(signal[idx_snr])
         idx_inside = np.where(signal >= meanmin_signal)[0]
         idx_outside = np.where(signal < meanmin_signal)[0]
 
+    if threshold_method == "isophote":
+        if min_snr == 0:
+            # No spatial masking requested.
+            inside_mask = np.ones(signal.shape, dtype=bool)
+            outside_mask = np.zeros(signal.shape, dtype=bool)
+        else:
+
+            # Use only valid pixels to estimate the flux corresponding to the requested S/N.
+            valid = np.isfinite(signal) & np.isfinite(snr)
+            snr_valid = snr[valid]
+            signal_valid = signal[valid]
+
+            # Estimate the isophote from the 100 spaxels with S/N closest to the requested value.
+            N_SNR_SAMPLES = min(100, snr_valid.size)
+            idx = np.argsort(np.abs(snr_valid - min_snr))[:N_SNR_SAMPLES]
+            meanmin_signal = np.mean(signal_valid[idx])
+
+            # Create a mask from the corresponding flux isophote.
+            inside_mask = signal >= meanmin_signal
+            outside_mask = signal < meanmin_signal
+
+        idx_inside = np.where(inside_mask)
+        idx_outside = np.where(outside_mask)
+
+    if threshold_method == "isophote_smooth":
+
+        if min_snr == 0:
+            # No spatial masking requested.
+            inside_mask = np.ones(signal.shape, dtype=bool)
+            outside_mask = np.zeros(signal.shape, dtype=bool)
+
+        else:
+            # Use only valid spaxels to estimate the flux corresponding to the requested S/N.
+            valid_1d = np.isfinite(signal) & np.isfinite(snr)
+            snr_valid = snr[valid_1d]
+            signal_valid = signal[valid_1d]
+
+            # Estimate the isophote from the 100 spaxels with S/N closest to the requested value.
+            N_SNR_SAMPLES = min(100, snr_valid.size)
+            idx = np.argsort(np.abs(snr_valid - min_snr))[:N_SNR_SAMPLES]
+            meanmin_signal = np.mean(signal_valid[idx])
+
+            # Reconstruct the 2D signal map.
+            x_vals = np.unique(np.round(cube["x"], 10))
+            y_vals = np.unique(np.round(cube["y"], 10))
+            ix = np.searchsorted(x_vals, np.round(cube["x"], 10))
+            iy = np.searchsorted(y_vals, np.round(cube["y"], 10))
+
+            signal_2d = np.full((y_vals.size, x_vals.size), np.nan)
+            signal_2d[iy, ix] = signal
+
+            # Smooth the 2D flux map.
+            mask_2d = np.isfinite(signal_2d)
+            signal_filled = np.where(mask_2d, signal_2d, 0.0)
+
+            smoothed_signal = gaussian_filter(signal_filled, sigma=smooth_sigma)
+            smoothed_mask = gaussian_filter(mask_2d.astype(float), sigma=smooth_sigma)
+
+            with np.errstate(divide="ignore", invalid="ignore"):
+                smoothed_signal = smoothed_signal / smoothed_mask
+            smoothed_signal[smoothed_mask == 0] = np.nan
+
+            # Threshold the smoothed map.
+            inside_mask_2d = smoothed_signal >= meanmin_signal
+
+            # Keep only the largest connected region above the threshold.
+            labels, nlab = label(inside_mask_2d)
+            if nlab > 0:
+                counts = np.bincount(labels.ravel())
+                counts[0] = 0  # ignore background
+                main_label = np.argmax(counts)
+                inside_mask_2d = labels == main_label
+            else:
+                inside_mask_2d = np.zeros_like(inside_mask_2d, dtype=bool)
+
+            # Map back to the original 1D spaxel order.
+            inside_mask = inside_mask_2d[iy, ix]
+            outside_mask = ~inside_mask
+
+        idx_inside = np.where(inside_mask)[0]
+        idx_outside = np.where(outside_mask)[0]
+
     if threshold_method == "actual":
         idx_inside = np.where(snr >= min_snr)[0]
         idx_outside = np.where(snr < min_snr)[0]
 
-    if threshold_method == "smooth":
+    if threshold_method == "actual_smooth":
 
-        mask = np.isfinite(snr)
-        snr_filled = np.where(mask, snr, 0.0)
+        x_vals, y_vals, ix, iy = build_spatial_grid(cube)
 
-        smoothed_snr = gaussian_filter(snr_filled, sigma=5.0)
-        smoothed_mask = gaussian_filter(mask.astype(float), sigma=5.0)
+        # Reconstruct the 2D S/N map and smooth it.
+        snr_2d = values_to_2d(snr, x_vals, y_vals, ix, iy)
+        mask_2d = np.isfinite(snr_2d)
+        snr_filled = np.where(mask_2d, snr_2d, 0.0)
 
-        smoothed = smoothed_snr / smoothed_mask
+        smoothed_snr = gaussian_filter(snr_filled, sigma=smooth_sigma)
+        smoothed_mask = gaussian_filter(mask_2d.astype(float), sigma=smooth_sigma)
 
-        idx_inside = np.where(smoothed >= min_snr)[0]
-        idx_outside = np.where(smoothed < min_snr)[0]        
+        with np.errstate(divide="ignore", invalid="ignore"):
+            smoothed_snr = smoothed_snr / smoothed_mask
+        smoothed_snr[smoothed_mask == 0] = np.nan
+
+        # Threshold the smoothed map.
+        inside_mask_2d = smoothed_snr >= min_snr
+
+        # Keep only the largest connected region above the threshold.
+        labels, nlab = label(inside_mask_2d)
+        if nlab > 0:
+            counts = np.bincount(labels.ravel())
+            counts[0] = 0  # ignore background
+            main_label = np.argmax(counts)
+            inside_mask_2d = labels == main_label
+        else:
+            inside_mask_2d = np.zeros_like(inside_mask_2d, dtype=bool)
+
+        # Map back to the original 1D spaxel ordering.
+        inside_mask = inside_mask_2d[iy, ix]
+        outside_mask = ~inside_mask
+
+        idx_inside = np.where(inside_mask)[0]
+        idx_outside = np.where(outside_mask)[0]  
 
     if len(idx_inside) == 0 and len(idx_outside) == 0:
         idx_inside = np.arange(len(snr))


### PR DESCRIPTION
V7.6.12     2026-07-27 ADDED: new and updated masking routines. YAML file now takes 
		    keyword THRESHOLD_METHOD:'isophote', 'isophote_gist' 'actual', 
			'isophote_smooth', 'actual_smooth'; The old version is isophote_gist. When 
			calling a smooth version, you can use the SMOOTH_SIGMA keyword to set the
			size of the Gaussian smoothing. Setting min_snr=0.0 results in all spaxels 
			being used.
